### PR TITLE
Bump languageVersion to 2.11.7

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -5,7 +5,7 @@ import AssemblyKeys._
 import com.typesafe.sbt.pgp.PgpKeys._
 
 object Settings {
-  lazy val languageVersion = "2.11.6"
+  lazy val languageVersion = "2.11.7"
   lazy val metaVersion = "0.1.0-SNAPSHOT"
 
   lazy val sharedSettings: Seq[sbt.Def.Setting[_]] = Seq(


### PR DESCRIPTION
Needed to get the latest version of scalahost

Without this change, `sbt compile` failed with:
```
[error] (compiletime/*:assembly) deduplicate: different file contents found in the following:
[error] /home/smarter/.ivy2/local/org.scalameta/foundation_2.11/0.1.0-SNAPSHOT/jars/foundation_2.11.jar:org/scalameta/UnreachableError$$anonfun$1.class
[error] /home/smarter/.ivy2/cache/org.scalameta/scalahost_2.11.6/jars/scalahost_2.11.6-0.1.0-SNAPSHOT.jar:org/scalameta/UnreachableError$$anonfun$1.class
```